### PR TITLE
no local package install in requirements.txt

### DIFF
--- a/dagster_cloud.yaml
+++ b/dagster_cloud.yaml
@@ -2,3 +2,4 @@ locations:
   - location_name: example_location
     code_source:
       package_name: my_dagster_project
+    working_directory: ./my-dagster-project

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-./my-dagster-project
+dagster
 dagster-cloud


### PR DESCRIPTION
i think the assumption is safe

two cases:
1. if requirements.txt exists, it should include all the required dependencies for deployment -- this should work for projects that are larger and need pip caching to be enabled cross builds. in this case, we don't recommend including, **so i'm taking out the local package in this example and point the working directory at it.**
2. if requirements.txt doesnt exist, it's highly likely there's a setup.py in the root -- this should be a minimal/starter case and our dockerfile falls back to install from local package `pip install .`