### PR TITLE
turn off baking GH secrets into the serverless image by default

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -2,7 +2,7 @@ name: Serverless Branch Deployments
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
-concurrency: 
+concurrency:
   # Cancel in-progress runs on same branch
   group: ${{ github.ref }}
   cancel-in-progress: true
@@ -41,6 +41,7 @@ jobs:
         with:
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}
-          env_vars: ${{ toJson(secrets) }}
+          # Uncomment to pass through Github Action secrets as a JSON string of key-value pairs
+          # env_vars: ${{ toJson(secrets) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - "main"
       - "master"
-concurrency: 
+concurrency:
   # Cancel in-progress deploys to main branch
   group: ${{ github.ref }}
   cancel-in-progress: true
@@ -43,6 +43,7 @@ jobs:
         with:
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}
-          env_vars: ${{ toJson(secrets) }}
+          # Uncomment to pass through Github Action secrets as a JSON string of key-value pairs
+          # env_vars: ${{ toJson(secrets) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We'll have to change the instructions here as well:
https://docs.dagster.io/dagster-cloud/deployment/serverless#adding-secrets