### PR TITLE
remove org_id env ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Set up secrets on your newly created repository by navigating to the `Settings` 
 | Name                      | Description                                                                                                                                                                                                     |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DAGSTER_CLOUD_API_TOKEN` | An agent token, for more details see [the Dagster Cloud docs](https://docs.dagster.cloud/auth#managing-user-and-agent-tokens).                                                                                  |
-| `ORGANIZATION_ID`         | The organization ID of your Dagster Cloud organization, found in the URL. For example, `pied-piper` if your organization is found at `https://dagster.cloud/pied-piper` or `https://pied-piper.dagster.cloud/`. |
 
 ## Verify Builds are Successful
 


### PR DESCRIPTION
I believe that this is not needed anymore since the changes to fetching org details?