### PR TITLE
Revert "Pass through ORGANIZATION_ID secret in serverless quickstart …

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Build and deploy to Dagster Cloud serverless
         uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v0.1
         with:
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}
           # Uncomment to pass through Github Action secrets as a JSON string of key-value pairs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Build and deploy to Dagster Cloud serverless
         uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v0.1
         with:
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}
           # Uncomment to pass through Github Action secrets as a JSON string of key-value pairs


### PR DESCRIPTION
…template (#19)"

This reverts commit 2b0b4237bd8e469f57f867a04e50f8208d94efc2.

https://elementl-workspace.slack.com/archives/C03A0D72A6T/p1665031054185919
organization_id entry already existed. the commit resulted in duplication.

## test plan
quickstart github action deployed successfully