### PR TITLE
move dagster-cloud to setup.py, remove requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-.
-dagster-cloud

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["my_dagster_project_tests"]),
         install_requires=[
             "dagster",
-            "dagster_aws",
-            "dagster_cloud",
+            "dagster-aws",
+            "dagster-cloud",
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ if __name__ == "__main__":
         install_requires=[
             "dagster",
             "dagster_aws",
+            "dagster_cloud",
         ],
     )


### PR DESCRIPTION
having both is confusing. this pr moves dagster-cloud (**should it be `dagster-cloud` or `dagster_cloud`??**) to setup.py and gets rid of requirements.txt. note that this means in local dev, the user would install dagster-cloud (which is probably fine and maybe preferred because it includes the deploy CLI)

## Test plan
```
~/dev/dagster-cloud-serverless-quickstart main*
demo-1006 $ dagster-cloud configure
demo-1006 $ dagster-cloud serverless deploy \
  --location-name status-quo-quickstart \
  --package-name myd_agster_project
```
deployed the code location successfully -- i believe we don't need to deal with backcompat because the dockerfile does pip install conditionally based on the existence of requirements.txt and setup.py
