### PR TITLE
Enable fast deploys for new sign-ups

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -9,6 +9,7 @@ concurrency:
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  ENABLE_FAST_DEPLOYS: 'true'
 
 jobs:
   dagster_cloud_default_deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  ENABLE_FAST_DEPLOYS: 'true'
 
 jobs:
   dagster_cloud_default_deploy:


### PR DESCRIPTION
This change is not related to any push and can be reverted any time.

Users that cloned the repo when this is enabled will need to turn in off in their cloned repo.