### PR TITLE
Enable fast deploys

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -9,6 +9,7 @@ concurrency:
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  ENABLE_FAST_DEPLOYS: 'true'
 
 jobs:
   dagster_cloud_default_deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  ENABLE_FAST_DEPLOYS: 'true'
 
 jobs:
   dagster_cloud_default_deploy:


### PR DESCRIPTION
Second attempt at https://github.com/dagster-io/dagster-cloud-serverless-quickstart/pull/25

Updated underlying dagster-cloud-action `@pex-v0.1` to increase the timeout for agent heartbeats.

Set ENABLE_FAST_DEPLOYS: 'true'